### PR TITLE
fix addToSet and push to support each op

### DIFF
--- a/pkg/mongoproxy/plugins/schema/type_test.go
+++ b/pkg/mongoproxy/plugins/schema/type_test.go
@@ -199,6 +199,10 @@ var (
 		// push extra field
 		{DB: "testdb", Collection: "requireonlysuba", In: bson.D{{"$push", bson.D{{"doc.a", "name"}, {"doc.b", 1}}}}, Err: true},
 		{DB: "testdb", Collection: "requireonlysuba", In: bson.D{{"$push", bson.D{{"a", "name"}, {"doc.b", 1}}}}, Err: true},
+		//test with each
+		{DB: "testdb", Collection: "nonrequire", In: bson.D{{"$push", bson.D{{"luckynumbers", bson.D{{"$each", bson.A{1, 2, 3}}}}}}}},
+		//test with each
+		{DB: "testdb", Collection: "nonrequire", In: bson.D{{"$push", bson.D{{"luckynumbers", bson.E{"$each", bson.A{1, 2, 3}}}}}}},
 
 		//
 		// pull tests
@@ -337,6 +341,10 @@ var (
 		// addToSet extra field
 		{DB: "testdb", Collection: "requireonlysuba", In: bson.D{{"$addToSet", bson.D{{"doc.a", "name"}, {"doc.b", 1}}}}, Err: true},
 		{DB: "testdb", Collection: "requireonlysuba", In: bson.D{{"$addToSet", bson.D{{"a", "name"}, {"doc.b", 1}}}}, Err: true},
+		//test with each
+		{DB: "testdb", Collection: "nonrequire", In: bson.D{{"$addToSet", bson.D{{"luckynumbers", bson.D{{"$each", bson.A{1, 2, 3}}}}}}}},
+		//test with each
+		{DB: "testdb", Collection: "nonrequire", In: bson.D{{"$addToSet", bson.D{{"luckynumbers", bson.E{"$each", bson.A{1, 2, 3}}}}}}},
 
 		//
 		// rename tests

--- a/pkg/mongoproxy/plugins/schema/types.go
+++ b/pkg/mongoproxy/plugins/schema/types.go
@@ -267,7 +267,7 @@ func (c *Collection) ValidateUpdate(ctx context.Context, obj bson.D, upsert bool
 				}
 			case "$rename":
 				renameFields = e.Value.(bson.D).Map()
-			case "$set", "$pull", "$push", "$addToSet", "$pullAll":
+			case "$set", "$pull", "$pullAll":
 				if setFields == nil {
 					setFields = Mapify(e.Value.(bson.D))
 				} else {
@@ -276,6 +276,12 @@ func (c *Collection) ValidateUpdate(ctx context.Context, obj bson.D, upsert bool
 						setFields[item.Key] = item.Value
 					}
 				}
+			case "$addToSet", "$push":
+				if setFields == nil {
+					setFields = make(bson.M, len(e.Value.(bson.D)))
+				}
+				setFields = MapifyWithOp(e.Value.(bson.D), setFields)
+
 			case "$setOnInsert":
 				insertFields = Mapify(e.Value.(bson.D))
 			case "$unset":

--- a/pkg/mongoproxy/plugins/schema/util.go
+++ b/pkg/mongoproxy/plugins/schema/util.go
@@ -155,7 +155,7 @@ func MapifyWithOp(d bson.D, m bson.M) bson.M {
 				m[e.Key] = val
 				continue
 			}
-		} else if _, ok := e.Value.(primitive.D); ok && e.Value.(bson.E).Key == "$each" {
+		} else if _, ok := e.Value.(primitive.E); ok && e.Value.(bson.E).Key == "$each" {
 			m[e.Key] = e.Value.(bson.E).Value
 			continue
 		}

--- a/pkg/mongoproxy/plugins/schema/util.go
+++ b/pkg/mongoproxy/plugins/schema/util.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"regexp"
 
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -137,6 +140,27 @@ func Mapify(d bson.D) bson.M {
 	for _, e := range d {
 		e := processArray(e)
 		m[e.Key] = e.Value
+	}
+	return m
+}
+
+// Map creates a map from the elements of the D with operator
+// It makes additional process for arrays
+func MapifyWithOp(d bson.D, m bson.M) bson.M {
+	for _, e := range d {
+		e := processArray(e)
+		if _, ok := e.Value.(primitive.D); ok {
+			itemValueSet := e.Value.(bson.D).Map()
+			if val, ok := itemValueSet["$each"]; ok {
+				m[e.Key] = val
+				continue
+			}
+		} else if _, ok := e.Value.(primitive.D); ok && e.Value.(bson.E).Key == "$each" {
+			m[e.Key] = e.Value.(bson.E).Value
+			continue
+		}
+		m[e.Key] = e.Value
+		logrus.Debugf("Add %s type element to set", fmt.Sprint(reflect.TypeOf(e.Value)))
 	}
 	return m
 }


### PR DESCRIPTION
fix issue: 
https://logicians.slack.com/archives/C0133DZ2WE8/p1658528214943319

in mongodb $addToSet and $push command support each operator:

https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/#-each-modifier
https://www.mongodb.com/docs/manual/reference/operator/update/push/#modifiers