### PR TITLE
enable collection level schema log only

### DIFF
--- a/pkg/mongoproxy/plugins/schema/types.go
+++ b/pkg/mongoproxy/plugins/schema/types.go
@@ -7,6 +7,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -42,6 +45,10 @@ const (
 )
 
 var OpMap = BuildUpdateOpSet()
+var collectionSchemaLogOnlyDeny = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "mongoproxy_plugins_collection_level_logonly_schema_deny_total",
+	Help: "The total deny returns of a command",
+}, []string{"collection", "command"})
 
 type ClusterSchema struct {
 	MongosEndpoint       string              `json:"mongosEndpoint"`
@@ -157,6 +164,7 @@ func (d *Database) ValidateInsert(ctx context.Context, collection string, obj bs
 	}
 	if c.EnforceSchemaByCollectionLogOnly {
 		if err := c.ValidateInsert(ctx, obj); err != nil {
+			collectionSchemaLogOnlyDeny.WithLabelValues(collection, "insert").Inc()
 			logrus.Errorf("COLLECTION ENFORCE LOG ONLY: %s", err.Error())
 			return nil
 		}
@@ -176,6 +184,7 @@ func (d *Database) ValidateUpdate(ctx context.Context, collection string, obj bs
 	}
 	if c.EnforceSchemaByCollectionLogOnly {
 		if err := c.ValidateUpdate(ctx, obj, upsert); err != nil {
+			collectionSchemaLogOnlyDeny.WithLabelValues(collection, "update").Inc()
 			logrus.Errorf("COLLECTION ENFORCE LOG ONLY: %s", err.Error())
 			return nil
 		}


### PR DESCRIPTION
`time="2022-09-28T21:58:11Z" level=error msg="COLLECTION ENFORCE LOG ONLY: wrong data type: expecting a bool for field Deleted, but got float64 with value %!s(float64=1)"`
tested in stage collection