### PR TITLE
support dbstats

### DIFF
--- a/pkg/command/dbstats.go
+++ b/pkg/command/dbstats.go
@@ -1,0 +1,37 @@
+package command
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/wish/mongoproxy/pkg/bsonutil"
+)
+
+func init() {
+	Register("dbstats", func() Command {
+		return &DbStats{}
+	})
+	Register("dbStats", func() Command {
+		return &DbStats{}
+	})
+}
+
+// the struct for the 'find' command.
+type DbStats struct {
+	DbStats int `bson:"dbstats"`
+	Scale   int `bson:"scale,omitempty"`
+
+	Common `bson:",inline"`
+}
+
+func (m *DbStats) FromBSOND(d bson.D) error {
+	dec, err := bson.NewDecoder(bsonutil.NewStrictValueReader(d))
+	if err != nil {
+		return err
+	}
+
+	if err := dec.Decode(&m); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/mongoproxy/plugins/mongo/mongo.go
+++ b/pkg/mongoproxy/plugins/mongo/mongo.go
@@ -412,6 +412,12 @@ func (p *MongoPlugin) Process(ctx context.Context, r *plugins.Request, next plug
 
 		return runCommand(ctx, dbName, cmd, nil)
 
+	case *command.DbStats:
+		dbName := cmd.Database
+		cmd.Database = ""
+
+		return runCommand(ctx, dbName, cmd, nil)
+
 	case *command.Drop:
 		// TODO: some other way to not double-send the DB
 		dbName := cmd.Database


### PR DESCRIPTION
```
> db.stats(200)
{
        "db" : "test",
        "collections" : 0,
        "views" : 0,
        "objects" : 0,
        "avgObjSize" : 0,
        "dataSize" : 0,
        "storageSize" : 0,
        "totalSize" : 0,
        "indexes" : 0,
        "indexSize" : 0,
        "scaleFactor" : 200,
        "fileSize" : 0,
        "fsUsedSize" : 0,
        "fsTotalSize" : 0,
        "ok" : 1
}
> db.runCommand({dbStats:1})
{
        "db" : "test",
        "collections" : 0,
        "views" : 0,
        "objects" : 0,
        "avgObjSize" : 0,
        "dataSize" : 0,
        "storageSize" : 0,
        "totalSize" : 0,
        "indexes" : 0,
        "indexSize" : 0,
        "scaleFactor" : 1,
        "fileSize" : 0,
        "fsUsedSize" : 0,
        "fsTotalSize" : 0,
        "ok" : 1
}

```