### PR TITLE
add client info into metric labels

### DIFF
--- a/pkg/mongoproxy/plugins/interface.go
+++ b/pkg/mongoproxy/plugins/interface.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"net"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
 
@@ -61,6 +62,10 @@ type Request struct {
 
 func (r *Request) Close() {}
 
+func (r *Request) GetClientInfo() string {
+	return r.CC.GetClientInfo()
+}
+
 func NewClientConnection() *ClientConnection {
 	return &ClientConnection{
 		Map: map[interface{}]interface{}{},
@@ -76,6 +81,25 @@ type ClientConnection struct {
 
 	// Map is storage that resets on cursor change
 	Map map[interface{}]interface{}
+}
+
+func (c *ClientConnection) GetUsername() string {
+	var usernames []string
+	for _, identity := range c.Identities {
+		usernames = append(usernames, identity.User())
+	}
+	var username string
+	if len(usernames) > 0 {
+		username = strings.Join(usernames, ",")
+	} else {
+		username = "unknown"
+	}
+	return username
+}
+
+func (c *ClientConnection) GetClientInfo() string {
+	//todo @jiapeng use username or client ip?
+	return c.GetAddr()
 }
 
 func (c *ClientConnection) GetAddr() string {

--- a/pkg/mongoproxy/plugins/mongo/mongo.go
+++ b/pkg/mongoproxy/plugins/mongo/mongo.go
@@ -34,15 +34,15 @@ var (
 		Help:       "The duration of mongo commands",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, 1.0: 0.0},
 		MaxAge:     time.Minute,
-	}, []string{"db", "collection", "command", "readpref"})
+	}, []string{"client", "db", "collection", "command", "readpref"})
 	commandInflight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "mongoproxy_plugins_mongo_command_inflight",
 		Help: "The duration of mongo commands",
-	}, []string{"db", "collection", "command", "readpref"})
+	}, []string{"client", "db", "collection", "command", "readpref"})
 	commandReceiveBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_command_receive_bytes_total",
 		Help: "The total number of bytes received from downstream",
-	}, []string{"db", "collection", "command", "readpref"})
+	}, []string{"client", "db", "collection", "command", "readpref"})
 	mongoDiscoveryUpdate = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_discovery_update",
 		Help: "The total number of updates from discovery",
@@ -262,6 +262,7 @@ func (p *MongoPlugin) Process(ctx context.Context, r *plugins.Request, next plug
 	start := time.Now()
 
 	labels := []string{
+		r.GetClientInfo(),
 		command.GetCommandDatabase(r.Command),
 		command.GetCommandCollection(r.Command),
 		r.CommandName,

--- a/pkg/mongoproxy/proxy.go
+++ b/pkg/mongoproxy/proxy.go
@@ -35,18 +35,18 @@ import (
 )
 
 var (
-	clientConnectionCounter = promauto.NewCounter(prometheus.CounterOpts{
+	clientConnectionCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_client_accept_total",
 		Help: "The total number of accepted client connections",
-	})
-	clientConnectionGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	}, []string{"client"})
+	clientConnectionGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "mongoproxy_client_connections_open",
 		Help: "The current number of open client client connections",
-	})
+	}, []string{"client"})
 	clientMessageCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_client_message_total",
 		Help: "The total number of messages from clients",
-	}, []string{"opcode"})
+	}, []string{"client", "opcode"})
 
 	ErrServerClosed = errors.New("server closed")
 	SKIP_RECOVER    = false
@@ -328,12 +328,16 @@ func (p *Proxy) Serve() error {
 			}
 			return err
 		}
-		clientConnectionCounter.Inc()
-		clientConnectionGauge.Inc()
+
+		labels := []string{
+			c.RemoteAddr().String(),
+		}
+		clientConnectionCounter.WithLabelValues(labels...).Inc()
+		clientConnectionGauge.WithLabelValues(labels...).Inc()
 
 		go func(c net.Conn) {
 			defer func() {
-				clientConnectionGauge.Dec()
+				clientConnectionGauge.WithLabelValues(labels...).Dec()
 				if !SKIP_RECOVER {
 					if err := recover(); err != nil {
 						logrus.Errorf("Panic in connection: %v", err)
@@ -421,7 +425,7 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 func (p *Proxy) handleOp(ctx context.Context, clientConn *plugins.ClientConnection, req *mongowire.Request) (mongowire.WireSerializer, error) {
 	logrus.Debugf("header received: %v", req.GetHeader())
 
-	clientMessageCounter.WithLabelValues(req.GetHeader().OpCode.String()).Inc()
+	clientMessageCounter.WithLabelValues(clientConn.GetClientInfo(), req.GetHeader().OpCode.String()).Inc()
 
 	switch req.GetHeader().OpCode {
 	case mongowire.OpQuery:


### PR DESCRIPTION
We will add client info into following metrics

- mongoproxy_plugins_mongo_command_duration_seconds
- mongoproxy_plugins_mongo_command_inflight
- mongoproxy_plugins_mongo_command_receive_bytes_total
- mongoproxy_client_accept_total
- mongoproxy_client_connections_open
- mongoproxy_client_message_total
