### PR TITLE
add client info into metric labels

### DIFF
--- a/pkg/mongoproxy/plugins/authz/authzlib/resource.go
+++ b/pkg/mongoproxy/plugins/authz/authzlib/resource.go
@@ -12,6 +12,7 @@ type Resource struct {
 }
 
 // getResource receives a map[string]string and returns the global, dbs, collections and fields
+//
 //	it is attempting to access.
 func getResource(resource map[string]string) (r Resource, err error) {
 	if resource["Global"] == "*" {

--- a/pkg/mongoproxy/plugins/authz/authzlib/utils.go
+++ b/pkg/mongoproxy/plugins/authz/authzlib/utils.go
@@ -26,14 +26,15 @@ func appendArrayIfMissing(slice []string, other []string) []string {
 }
 
 // splitURI receives a uri and returns the dbs, collections and fields
+//
 //	it is attempting to access.
 //
 // uri examples:
+//
 //	db/coll/fld -> [db] [coll] [fld]
 //	db/coll/* -> [db] [coll] [*]
 //	db/coll/fld1,fld2 -> [db] [coll] [fld1 fld2]
 //	db/*/fld1,fld2 -> [db] [*] [fld1 fld2]
-//
 func splitURI(uri string) ([]string, []string, []string, error) {
 	parts := strings.Split(uri, "/")
 	if len(parts) > 3 {
@@ -65,9 +66,11 @@ func splitURI(uri string) ([]string, []string, []string, error) {
 // (e.g. some tree) which can evaluate the permissions without having to expand to
 // all possible options
 // expandResource returns a slice of potential resources that can appear
+//
 //	in config given a single resource.
 //
 // Example:
+//
 //	db/coll/fld -> [db/coll/fld db/coll/* db/*/fld db/*/*
 //					*/coll/fld */*/fld */coll/* */*/*]
 func expandResource(r Resource) []Resource {

--- a/pkg/mongoproxy/plugins/interface.go
+++ b/pkg/mongoproxy/plugins/interface.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"net"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
 
@@ -61,6 +62,10 @@ type Request struct {
 
 func (r *Request) Close() {}
 
+func (r *Request) GetClientInfo() string {
+	return r.CC.GetClientInfo()
+}
+
 func NewClientConnection() *ClientConnection {
 	return &ClientConnection{
 		Map: map[interface{}]interface{}{},
@@ -78,11 +83,30 @@ type ClientConnection struct {
 	Map map[interface{}]interface{}
 }
 
+func (c *ClientConnection) GetUsername() string {
+	var usernames []string
+	for _, identity := range c.Identities {
+		usernames = append(usernames, identity.User())
+	}
+	var username string
+	if len(usernames) > 0 {
+		username = strings.Join(usernames, ",")
+	} else {
+		username = "unknown"
+	}
+	return username
+}
+
 func (c *ClientConnection) GetAddr() string {
 	if c.Addr == nil {
 		return ""
 	}
 	return c.Addr.String()
+}
+
+func (c *ClientConnection) GetClientInfo() string {
+	//todo @jiapeng use username or client ip?
+	return c.GetAddr()
 }
 
 func (c *ClientConnection) Close() {}

--- a/pkg/mongoproxy/plugins/interface.go
+++ b/pkg/mongoproxy/plugins/interface.go
@@ -104,18 +104,8 @@ func (c *ClientConnection) GetIpAddr() string {
 	if c.Addr == nil {
 		return ""
 	}
-
 	addr := c.Addr.String()
-
-	if strings.Contains(addr, ":") {
-		addr = strings.Split(addr, ":")[0]
-	}
-
-	return addr
-}
-
-func (c *ClientConnection) GetClientInfo() string {
-	return c.GetUsername() + "(" + c.GetIpAddr() + ")"
+	return strings.Split(addr, ":")[0]
 }
 
 func (c *ClientConnection) Close() {}

--- a/pkg/mongoproxy/plugins/interface.go
+++ b/pkg/mongoproxy/plugins/interface.go
@@ -62,10 +62,6 @@ type Request struct {
 
 func (r *Request) Close() {}
 
-func (r *Request) GetClientInfo() string {
-	return r.CC.GetClientInfo()
-}
-
 func NewClientConnection() *ClientConnection {
 	return &ClientConnection{
 		Map: map[interface{}]interface{}{},
@@ -104,9 +100,22 @@ func (c *ClientConnection) GetAddr() string {
 	return c.Addr.String()
 }
 
+func (c *ClientConnection) GetIpAddr() string {
+	if c.Addr == nil {
+		return ""
+	}
+
+	addr := c.Addr.String()
+
+	if strings.Contains(addr, ":") {
+		addr = strings.Split(addr, ":")[0]
+	}
+
+	return addr
+}
+
 func (c *ClientConnection) GetClientInfo() string {
-	//todo @jiapeng use username or client ip?
-	return c.GetAddr()
+	return c.GetUsername() + "(" + c.GetIpAddr() + ")"
 }
 
 func (c *ClientConnection) Close() {}

--- a/pkg/mongoproxy/plugins/mongo/mongo.go
+++ b/pkg/mongoproxy/plugins/mongo/mongo.go
@@ -34,15 +34,15 @@ var (
 		Help:       "The duration of mongo commands",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, 1.0: 0.0},
 		MaxAge:     time.Minute,
-	}, []string{"db", "collection", "command", "readpref"})
+	}, []string{"client", "db", "collection", "command", "readpref"})
 	commandInflight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "mongoproxy_plugins_mongo_command_inflight",
 		Help: "The duration of mongo commands",
-	}, []string{"db", "collection", "command", "readpref"})
+	}, []string{"client", "db", "collection", "command", "readpref"})
 	commandReceiveBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_command_receive_bytes_total",
 		Help: "The total number of bytes received from downstream",
-	}, []string{"db", "collection", "command", "readpref"})
+	}, []string{"client", "db", "collection", "command", "readpref"})
 	mongoDiscoveryUpdate = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_discovery_update",
 		Help: "The total number of updates from discovery",
@@ -262,6 +262,7 @@ func (p *MongoPlugin) Process(ctx context.Context, r *plugins.Request, next plug
 	start := time.Now()
 
 	labels := []string{
+		r.GetClientInfo(),
 		command.GetCommandDatabase(r.Command),
 		command.GetCommandCollection(r.Command),
 		r.CommandName,

--- a/pkg/mongoproxy/plugins/mongo/mongo.go
+++ b/pkg/mongoproxy/plugins/mongo/mongo.go
@@ -38,11 +38,11 @@ var (
 	commandInflight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "mongoproxy_plugins_mongo_command_inflight",
 		Help: "The duration of mongo commands",
-	}, []string{"client", "client_name", "db", "collection", "command", "readpref"})
+	}, []string{"client_ip", "client_name", "db", "collection", "command", "readpref"})
 	commandReceiveBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_command_receive_bytes_total",
 		Help: "The total number of bytes received from downstream",
-	}, []string{"client", "client_name", "db", "collection", "command", "readpref"})
+	}, []string{"client_ip", "client_name", "db", "collection", "command", "readpref"})
 	mongoDiscoveryUpdate = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_discovery_update",
 		Help: "The total number of updates from discovery",

--- a/pkg/mongoproxy/plugins/mongo/mongo.go
+++ b/pkg/mongoproxy/plugins/mongo/mongo.go
@@ -34,15 +34,15 @@ var (
 		Help:       "The duration of mongo commands",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, 1.0: 0.0},
 		MaxAge:     time.Minute,
-	}, []string{"client", "db", "collection", "command", "readpref"})
+	}, []string{"client_ip", "client_name", "db", "collection", "command", "readpref"})
 	commandInflight = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "mongoproxy_plugins_mongo_command_inflight",
 		Help: "The duration of mongo commands",
-	}, []string{"client", "db", "collection", "command", "readpref"})
+	}, []string{"client", "client_name", "db", "collection", "command", "readpref"})
 	commandReceiveBytes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_command_receive_bytes_total",
 		Help: "The total number of bytes received from downstream",
-	}, []string{"client", "db", "collection", "command", "readpref"})
+	}, []string{"client", "client_name", "db", "collection", "command", "readpref"})
 	mongoDiscoveryUpdate = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "mongoproxy_plugins_mongo_discovery_update",
 		Help: "The total number of updates from discovery",
@@ -262,7 +262,8 @@ func (p *MongoPlugin) Process(ctx context.Context, r *plugins.Request, next plug
 	start := time.Now()
 
 	labels := []string{
-		r.GetClientInfo(),
+		r.CC.GetIpAddr(),
+		r.CC.GetUsername(),
 		command.GetCommandDatabase(r.Command),
 		command.GetCommandCollection(r.Command),
 		r.CommandName,

--- a/pkg/mongoproxy/proxy.go
+++ b/pkg/mongoproxy/proxy.go
@@ -424,7 +424,7 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 func (p *Proxy) handleOp(ctx context.Context, clientConn *plugins.ClientConnection, req *mongowire.Request) (mongowire.WireSerializer, error) {
 	logrus.Debugf("header received: %v", req.GetHeader())
 
-	lientMessageCounter.WithLabelValues(clientConn.GetClientInfo(), req.GetHeader().OpCode.String()).Inc()
+	clientMessageCounter.WithLabelValues(clientConn.GetClientInfo(), req.GetHeader().OpCode.String()).Inc()
 
 	switch req.GetHeader().OpCode {
 	case mongowire.OpQuery:


### PR DESCRIPTION
We will add client info into following metrics

- mongoproxy_plugins_mongo_command_duration_seconds
- mongoproxy_plugins_mongo_command_inflight
- mongoproxy_plugins_mongo_command_receive_bytes_total
- mongoproxy_client_accept_total
- mongoproxy_client_connections_open
- mongoproxy_client_message_total